### PR TITLE
Bugfix for the metrics_snapshot script

### DIFF
--- a/db/sqlite_query.py
+++ b/db/sqlite_query.py
@@ -70,7 +70,7 @@ class SQLiteQuery:
                 if state is not None:
                     issue["status"] = state.old_value
                 else:
-                    if issue["closed_on"] is not None and date < issue["closed_on"]:
+                    if issue["closed_on"] is not None and date < issue["closed_on"].date():
                         issue["status"] = "New"
 
         return issues_dict


### PR DESCRIPTION
- When running metrics_snapshot the following error occurs: project_management_statistics/db/sqlite_query.py", line 73, in status_snapshot if issue["closed_on"] is not None and date < date(issue["closed_on"]):

Problem is that we need to compare date with date and not datetime, which is what is stored in the closed_on column.